### PR TITLE
get_status arguments

### DIFF
--- a/jubatus/__init__.py
+++ b/jubatus/__init__.py
@@ -177,7 +177,7 @@ class Classifier(Accessor):
     def get_status(self):
         f = MPClientFunc(self.choose_one(), 'get_status')
         try:
-            (success, retval, error) = f()
+            (success, retval, error) = f(self.name)
             if not success:
                   raise RuntimeError(error)
         except RuntimeError, e:


### PR DESCRIPTION
In multi server environments, jubakeeper says "bad arguments" for get_status requests.
f() in get_status lacks "name" arguments.
