### PR TITLE
(hotfix) eliminate assertIsInstance in NN test

### DIFF
--- a/test/jubatus_test/nearest_neighbor/test.py
+++ b/test/jubatus_test/nearest_neighbor/test.py
@@ -46,7 +46,7 @@ class NearestNeighborTest(unittest.TestCase):
         TestUtil.kill_process(self.srv)
 
     def test_get_client(self):
-        self.assertIsInstance(self.cli.get_client(), msgpackrpc.client.Client)
+        self.assertTrue(isinstance(self.cli.get_client(), msgpackrpc.client.Client))
 
     def test_get_config(self):
         config = self.cli.get_config()


### PR DESCRIPTION
Remove unit test feature that is not available in python 2.6.

Reason why we need to treat this pull-req as hotfix:
- We want to support Python 2.6 in 0.5.0; assertIsInstance prevents running CI tests against python 2.6.: http://ci.jubat.us/job/jubatus-python-client/Branch=master,Python=2.6.6/
