### PR TITLE
fix test process handling (refs #38, #44)

### DIFF
--- a/test/jubatus_test/test_util.py
+++ b/test/jubatus_test/test_util.py
@@ -46,12 +46,12 @@ class TestUtil:
             if TestUtil.check_server(port):
                 raise Exception('Another server is already running')
             # use PIPE to surpress log messages of server processes
-            proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
             try:
                 TestUtil.wait_server(port, proc)
-            except e:
+            except Exception:
                 proc.kill()
-                raise e
+                raise
             if proc.poll():
                 stderr = proc.stderr.read()
                 raise Exception('Cannot run server process: \n' + stderr)


### PR DESCRIPTION
I am intentionally sending this pull-req to master branch, as it strongly impacts the operation of CI server.

Even after fixing #44, we got deadlock in CI server.
After investigation, I found that we should use `close_fds=True` in Popen constructor when running tests threaded (`nosetests` does this).

http://stackoverflow.com/questions/14615462/why-does-communicate-deadlock-when-used-with-multiple-popen-subprocesses
http://bugs.python.org/issue12786

I also fix another issue at the same time, which was introduced in #38, which was just a syntax error, causing process which failed to start does not stop correctly.