### PR TITLE
fix to manually decode strings in UTF-8 (fix #59)

### DIFF
--- a/jubatus/common/types.py
+++ b/jubatus/common/types.py
@@ -57,13 +57,11 @@ class TString(object):
         return m
 
     def from_msgpack(self, m):
+        if isinstance(m, binary_types):
+            m = m.decode('utf-8')
         check_types(m, string_types)
         return m
-        # if isinstance(m, str):
-        #     return m
-        # elif isinstance(m, bytes):
-        #     return m.decode()
-        
+
 class TDatum(object):
     def from_msgpack(self, m):
         from .datum import Datum


### PR DESCRIPTION
This patch fixes #59.

* Disable automatic conversion (decode) of RAW MessagePack bytes (change ``unpack_encoding`` from ``'utf-8'`` to ``None``), as binary data may be returned via RPC (e.g., ``decode_row`` of Recommender and ``get_core_members`` of Clustering).
* We manually decode RAW MessagePack bytes into UTF-8 only when we know its type a String.

See the comments  for details.