### PR TITLE
Add tests for set_label, get_labels and delete_label

### DIFF
--- a/test/jubatus_test/classifier/test.py
+++ b/test/jubatus_test/classifier/test.py
@@ -62,6 +62,17 @@ class ClassifierTest(unittest.TestCase):
         data = [d]
         result = self.cli.classify(data)
 
+    def test_set_label(self):
+        self.assertEqual(self.cli.set_label("label"), True)
+
+    def test_get_labels(self):
+        self.cli.set_label("label")
+        self.assertEqual(self.cli.get_labels(), {"label": 0})
+
+    def test_delete_label(self):
+        self.cli.set_label("label")
+        self.assertEqual(self.cli.delete_label("label"), True)
+
     def test_save(self):
         self.assertEqual(len(self.cli.save("classifier.save_test.model")), 1)
 


### PR DESCRIPTION
This patch is a part of https://github.com/jubatus/jubatus_core/pull/272

Currently, ``set_label``, ``get_labels``, ``delete_label`` are not tested.
I added tests about the above RPC and modified it to follow the new ``get_labels`` RPC signature.