### PR TITLE
validate constructor argument types (fix #68)

### DIFF
--- a/jubatus/common/client.py
+++ b/jubatus/common/client.py
@@ -54,6 +54,10 @@ class ClientBase(object):
       (`unpack_encoding=None`)
     """
     def __init__(self, host, port, name, timeout=10):
+        check_types(host, string_types)
+        check_types(port, int_types)
+        check_types(name, string_types)
+        check_types(timeout, int_types)
         address = msgpackrpc.Address(host, port)
         self.client = msgpackrpc.Client(address, timeout=timeout, pack_encoding='utf-8', unpack_encoding=None)
         self.jubatus_client = Client(self.client, name)
@@ -65,6 +69,7 @@ class ClientBase(object):
         return self.jubatus_client.name
 
     def set_name(self, name):
+        check_types(name, string_types)
         self.jubatus_client.name = name
 
     def save(self, id):

--- a/test/jubatus_test/common/test_client.py
+++ b/test/jubatus_test/common/test_client.py
@@ -67,5 +67,22 @@ class ClientTest(unittest.TestCase):
         self.assertEqual("test", c.call("test", [], AnyType(), []))
         self.assertRaises(TypeError, c.call, "test", [1], AnyType(), [])
 
+class ClientBaseTest(unittest.TestCase):
+    def test_constructor(self):
+        self.assertIsInstance(jubatus.common.ClientBase("127.0.0.1", 9199, "cluster", 10), jubatus.common.ClientBase)
+
+        # invalid host
+        self.assertRaises(TypeError, jubatus.common.ClientBase, 127001, 9199, "cluster", 10)
+
+        # invalid port
+        self.assertRaises(TypeError, jubatus.common.ClientBase, "127.0.0.1", "9199", "cluster", 10)
+
+        # invalid name
+        self.assertRaises(TypeError, jubatus.common.ClientBase, "127.0.0.1", 9199, 10, 10)
+
+        # invalid timeout
+        self.assertRaises(TypeError, jubatus.common.ClientBase, "127.0.0.1", 9199, "cluster", "test")
+        self.assertRaises(TypeError, jubatus.common.ClientBase, "127.0.0.1", 9199, "cluster", 1.5)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix #68.

When invalid value is specified for constructor, errors are immediately reported.

```py
>>> import jubatus
>>> jubatus.Classifier("localhost", 9199, 10, "cluster")  # <= the order of cluster name and timeout are reversed!
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "jubatus/classifier/client.py", line 12, in __init__
    super(Classifier, self).__init__(host, port, name, timeout)
  File "jubatus/common/client.py", line 59, in __init__
    check_types(name, string_types)
  File "jubatus/common/types.py", line 11, in check_types
    raise TypeError('type %s is expected, but %s is given' % (t, type(value)))
TypeError: type <type 'str'>, <type 'unicode'> is expected, but <type 'int'> is given
```