### PR TITLE
Add embedded_jubatus supports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 jubatus/*
 !jubatus/common/
+!jubatus/embedded.py
 *.egg-info
 *.egg
 *.pyc

--- a/generate.sh
+++ b/generate.sh
@@ -19,7 +19,8 @@ capitalize() {
 }
 
 for DIR in "${CLIENT_DIR}/jubatus/"*; do
-  if [ "$(basename "${DIR}")" != "common" ]; then
+  NAME="$(basename "${DIR}")"
+  if [ "${NAME}" != "common" -a "${NAME}" != "embedded.py" ]; then
     rm -rf $DIR
   fi
 done

--- a/jubatus/embedded.py
+++ b/jubatus/embedded.py
@@ -1,0 +1,42 @@
+__all__ = [
+    'Anomaly',
+    'Bandit',
+    'Burst',
+    'Classifier',
+    'Clustering',
+    'NearestNeighbor',
+    'Recommender',
+    'Regression',
+    'Stat',
+    'Graph',
+    'Weight',
+]
+
+class _EmbeddedUnavailable(object):
+    def __init__(self, *args, **kwargs):
+        raise RuntimeError('Embedded Jubatus Python module is not installed.')
+
+try:
+    from embedded_jubatus import Anomaly
+    from embedded_jubatus import Bandit
+    from embedded_jubatus import Burst
+    from embedded_jubatus import Classifier
+    from embedded_jubatus import Clustering
+    from embedded_jubatus import NearestNeighbor
+    from embedded_jubatus import Recommender
+    from embedded_jubatus import Regression
+    from embedded_jubatus import Stat
+    from embedded_jubatus import Weight
+    from embedded_jubatus import Graph
+except ImportError:
+    Anomaly = _EmbeddedUnavailable
+    Bandit = _EmbeddedUnavailable
+    Burst = _EmbeddedUnavailable
+    Classifier = _EmbeddedUnavailable
+    Clustering = _EmbeddedUnavailable
+    NearestNeighbor = _EmbeddedUnavailable
+    Recommender = _EmbeddedUnavailable
+    Regression = _EmbeddedUnavailable
+    Stat = _EmbeddedUnavailable
+    Graph = _EmbeddedUnavailable
+    Weight = _EmbeddedUnavailable


### PR DESCRIPTION
jubatusをRPC経由ではなくjubatus_coreを直接呼び出すembedded_pythonを
jubatusのpythonクライアントに組み込むます．

以下の @kmaehashi さんのコメントを元にしていますが，
https://github.com/kazuki/embedded-jubatus-python/issues/2#issuecomment-237428786

`from jubatus.classifier.client import Classifier, EmbeddedClassifier`

を実現するためには，jenerator に手を加える必要があるため，

`from jubatus.embedded import Anomaly, Bandit, Burst, Classifier, ...`

というふうに jubatus.embedded モジュールの中に全てのアルゴリズム用クラスをまとめました．

それと，これを機に embedded_jubatus を @kazuki 配下ではなく jubatus コミュニティの配下のリポジトリしたいのですが，どうでしょうか？